### PR TITLE
Support scanning null in JSON

### DIFF
--- a/scan_test.go
+++ b/scan_test.go
@@ -398,3 +398,34 @@ func TestSlash(t *testing.T) {
 		t.Fatalf("Expected %v for Scan, but %v:", 1, i)
 	}
 }
+
+func TestScanNull(t *testing.T) {
+	s := `{"foo":null}`
+	scan := func(i interface{}) error {
+		return ScanJSON(strings.NewReader(s), "/foo", i)
+	}
+
+	a := []interface{}{}
+	err := scan(&a)
+	if err != nil {
+		t.Error(err)
+	} else if a != nil {
+		t.Error("Expected an array to be nil")
+	}
+
+	m := map[string]interface{}{}
+	err = scan(&m)
+	if err != nil {
+		t.Error(err)
+	} else if m != nil {
+		t.Error("Expected a map to be nil")
+	}
+
+	var any Any
+	err = scan(&any)
+	if err != nil {
+		t.Error(err)
+	} else if any != nil {
+		t.Error("Expected an Any to be nil")
+	}
+}


### PR DESCRIPTION
I had a use case that I want to scan a path that possibly contains `null`. The current implemetation panics when I scan `null` because calling `reflect.Value.Type` panics at `tv := rv.Type().Kind()` in `Scan` when `rv` is `nil` of `interface{}` (i.e. `rv` is invalid). This pull request changes the behavior of `Scan` so that it can read null if `nil` can be assigned to `t`.

Notes:
* I didn't use `t.Run` to separate small test cases because other tests didn't use it (this is probably just because it wasn't available at the time)
* Error cases were already covered by existing tests (i.e. `TestScan` and `TestScanPanic`)

Concerns or possible improvements:
* The current error message "nil is not assignable" isn't very informative. It can be improved by using `fmt.Errorf` with the type information, or just calling `rt.IsNil()` and letting it panic would generate better error message. I wasn't sure if it'd be fine to use `fmt.Errorf` or you intentionally avoided using it, so I decided to make this PR with the minimal message. What do you think is good?
* Nil check and nil assignment check I wrote could be too much considering the use case of this library. Just check `if v == nil` might be enough. What do you think?